### PR TITLE
added status codes for pending, renamed other status codes

### DIFF
--- a/lib/omni_kassa/response.rb
+++ b/lib/omni_kassa/response.rb
@@ -2,8 +2,10 @@ module OmniKassa
   class Response
     RESPONSE_CODES = {
       0  => :success,
-      17 => :user_cancellation,
-      97 => :request_timeout
+      17 => :cancelled,
+      60 => :pending,
+      90 => :pending,
+      97 => :expired
     }
 
     attr_accessor :data, :seal, :order_id, :response_code, :amount

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -21,10 +21,13 @@ class ResponseTest < MiniTest::Unit::TestCase
     assert_equal :success, @response.response
 
     @response.response_code = 17
-    assert_equal :user_cancellation, @response.response
+    assert_equal :cancelled, @response.response
+
+    @response.response_code = 60
+    assert_equal :pending, @response.response
 
     @response.response_code = 97
-    assert_equal :request_timeout, @response.response
+    assert_equal :expired, @response.response
 
     @response.response_code = 1 # not 0
     assert_equal :unknown_failure, @response.response


### PR DESCRIPTION
Pending is self explanatory. Renamed other status codes (`:user_cancellation` => `:cancelled`, `:request_timeout` => `:expired`) to match what is in Rabobank's PHP lib:

``` php
// Translate transaction status code
protected function getTransactionStatus($sTransactionCode)
{
    if(in_array($sTransactionCode, array('00'))) // SUCCESS
    {
        return 'SUCCESS';
    }
    elseif(in_array($sTransactionCode, array('60', '90'))) // PENDING
    {
        return 'PENDING';
    }
    elseif(in_array($sTransactionCode, array('97'))) // EXPIRED
    {
        return 'EXPIRED';
    }
    elseif(in_array($sTransactionCode, array('17'))) // CANCELLED
    {
        return 'CANCELLED';
    }

    return 'FAILED';
}
```
