### PR TITLE
Removed explicit SSLv3 mentioning

### DIFF
--- a/lib/omni_kassa/request.rb
+++ b/lib/omni_kassa/request.rb
@@ -31,8 +31,7 @@ module OmniKassa
     end
 
     def perform
-      # SSLv3 is a TravisCI requirement; won't run otherwise
-      HTTParty.post(OmniKassa.url, query: query, ssl_version: :SSLv3).body
+      HTTParty.post(OmniKassa.url, query: query).body
     end
 
     def transaction_reference


### PR DESCRIPTION
Rabobank removed support for SSLv3 (rightfully so) and therefor the perform method with the explicit mentioning of `ssl_version: SSLv3` gave a SSL-error.

Without the explicit `ssl_version` it just works fine.

Fixes #8 
